### PR TITLE
Fix readme syntax

### DIFF
--- a/README.org
+++ b/README.org
@@ -5,18 +5,18 @@
 This a pre-configured flatpak manifest to build an emacs branch with libjanson, libgccjit and dependencies.
 This uses the latest releases of of all components, except for gcc, which has jit fixes in-tree and emacs, which has the experimental code bringing everything together.
 
-This simply glues everything together to in a trackable package rather than installing to `/usr/local/`
+This simply glues everything together to in a trackable package rather than installing to =/usr/local/=
 
-If you'd prefer traditional `./configure && make && make install` checkout the 'pgtk-nativecomp' branch here: https://github.com/fejfighter/emacs
+If you'd prefer traditional =./configure && make && make install= checkout the 'pgtk-nativecomp' branch here: https://github.com/fejfighter/emacs
 
 ** Building
    Based off the official documentation:
    https://docs.flatpak.org/en/latest/first-build.html
 
-1. `flatpak install org.gnome.sdk` (might also want to install the relevant theme you prefer)
-2. `flatpak-builder --repo=repo --force-clean build-dir org.gnu.emacs.json` - this will take some time
-3. `flatpak --user remote-add --no-gpg-verify emacs-repo repo` 
-4. `flatpack install emacs`
+1. =flatpak install org.gnome.sdk= (might also want to install the relevant theme you prefer)
+2. =flatpak-builder --repo=repo --force-clean build-dir org.gnu.emacs.json= - this will take some time
+3. =flatpak --user remote-add --no-gpg-verify emacs-repo repo= 
+4. =flatpack install emacs=
 
-Rebuilding is simply repeating steps 2 and running `flatpak update`.
+Rebuilding is simply repeating steps 2 and running =flatpak update=.
 


### PR DESCRIPTION
Github's org-mode parser won't accept backticks for code, you gotta fence with =equals= instead.