### PR TITLE
Add wrapper to call podman via flatpak-spawn

### DIFF
--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -179,6 +179,19 @@
                 "/share/icons/hicolor/scalable/mimetypes/emacs-document.svg",
                 "/share/icons/hicolor/scalable/mimetypes/emacs-document23.svg"
             ]
+        },
+        {
+            "name": "podman-wrapper",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm 755 podman-wrapper /app/bin/podman"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "podman-wrapper"
+                }
+            ]
         }
     ],
     "cleanup": [

--- a/podman-wrapper
+++ b/podman-wrapper
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+flatpak-spawn --host podman "$@"


### PR DESCRIPTION
When using toolbox-tramp with `toolbox-tramp-flatpak-wrap' set, it
will attempt to use flatpak-spawn even on remote machines, e.g.:

C-x C-f /ssh:user@remotehost|toolbox:fedora-toolbox-36

By shipping a podman wrapper inside the flatpak, toolbox tramp will
'do the right thing' everywhere