### PR TITLE
Provide access to user fonts

### DIFF
--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -23,6 +23,7 @@
 	"--filesystem=xdg-config/emacs:create",
 	"--filesystem=xdg-config/git:ro",
 	"--filesystem=xdg-data/emacs:create",
+	"--filesystem=xdg-data/fonts",
         "--filesystem=/tmp",
         "--filesystem=/var/tmp",
 	"--filesystem=xdg-run/gvfs"

--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -23,7 +23,7 @@
 	"--filesystem=xdg-config/emacs:create",
 	"--filesystem=xdg-config/git:ro",
 	"--filesystem=xdg-data/emacs:create",
-	"--filesystem=xdg-data/fonts",
+	"--filesystem=xdg-data/fonts:ro",
         "--filesystem=/tmp",
         "--filesystem=/var/tmp",
 	"--filesystem=xdg-run/gvfs"


### PR DESCRIPTION
I noticed the fonts I specified in my Emacs config did not load. This seems to fix the issue. I reckon choosing a custom font for Emacs is common, so I thought I'd make a pull request.

Thanks for this package – much appreciated!