### PR TITLE
bump to sdk gnome 45

### DIFF
--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnu.emacs-pgtk",
     "runtime" : "org.gnome.Sdk",
-    "runtime-version" : "43",
+    "runtime-version" : "45",
     "sdk" : "org.gnome.Sdk",
     "command": "emacs",
     "rename-icon": "emacs",


### PR DESCRIPTION
By running flatpak update, I was informed that:

```
Info: runtime org.gnome.Platform branch 43 is end-of-life, with reason:
   The GNOME 43 runtime is no longer supported as of September 20, 2023. Please ask your application developer to migrate to a supported platform.
Info: applications using this runtime:
```

I bumped the GNOME version to 45.