### PR TITLE
Remove libjansson dependency

### DIFF
--- a/metainfo-caption-point.patch
+++ b/metainfo-caption-point.patch
@@ -1,0 +1,25 @@
+From ce2214e2b2c42c9aea1b56c2594bcf760ebe39f3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joonas=20Saraj=C3=A4rvi?= <muep@iki.fi>
+Date: Mon, 4 Apr 2022 21:06:03 +0300
+Subject: [PATCH] Fix caption style to avoid a forbidden point
+
+---
+ etc/emacs.metainfo.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/etc/emacs.metainfo.xml b/etc/emacs.metainfo.xml
+index 19c7d5c675..dc235f8c47 100644
+--- a/etc/emacs.metainfo.xml
++++ b/etc/emacs.metainfo.xml
+@@ -41,7 +41,7 @@
+  <screenshots>
+   <screenshot type="default">
+     <image type="source" width="1024" height="576">https://www.gnu.org/software/emacs/images/appdata-26.png</image>
+-    <caption>Editing a Lisp program whilst viewing the Emacs manual.</caption>
++    <caption>Editing a Lisp program whilst viewing the Emacs manual</caption>
+   </screenshot>
+  </screenshots>
+  <update_contact>emacs-devel_AT_gnu.org</update_contact>
+-- 
+2.35.1
+

--- a/metainfo-content-rating.patch
+++ b/metainfo-content-rating.patch
@@ -1,0 +1,24 @@
+From f5554c0bfd9f4de71ad0ee92780f3641dea2bea0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joonas=20Saraj=C3=A4rvi?= <muep@iki.fi>
+Date: Mon, 4 Apr 2022 20:29:03 +0300
+Subject: [PATCH] Add content_rating to metainfo.xml
+
+---
+ etc/emacs.metainfo.xml | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/etc/emacs.metainfo.xml b/etc/emacs.metainfo.xml
+index 23d0b2cade..37c5debc7a 100644
+--- a/etc/emacs.metainfo.xml
++++ b/etc/emacs.metainfo.xml
+@@ -53,4 +53,7 @@
+    <release date="2019-04-12" version="26.2"/>
+    <release date="2018-05-28" version="26.1"/>
+  </releases>
++ <content_rating type="oars-1.0">
++   <content_attribute id="social-chat">intense</content_attribute>
++ </content_rating>
+ </component>
+-- 
+2.35.1
+

--- a/metainfo-launchable.patch
+++ b/metainfo-launchable.patch
@@ -1,0 +1,25 @@
+From fd8e2ac120c84d695a2c6a73d45e84314b7f673e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joonas=20Saraj=C3=A4rvi?= <muep@iki.fi>
+Date: Mon, 4 Apr 2022 20:27:26 +0300
+Subject: [PATCH] metainfo:  Update the launchable id
+
+---
+ etc/emacs.metainfo.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/etc/emacs.metainfo.xml b/etc/emacs.metainfo.xml
+index 65234f87f4..23d0b2cade 100644
+--- a/etc/emacs.metainfo.xml
++++ b/etc/emacs.metainfo.xml
+@@ -33,7 +33,7 @@
+  <url type="help">https://www.gnu.org/software/emacs/documentation.html</url>
+  <url type="donation">https://my.fsf.org/donate/</url>
+  <url type="contact">https://lists.gnu.org/mailman/listinfo/emacs-devel/</url>
+- <launchable type="desktop-id">emacs.desktop</launchable>
++ <launchable type="desktop-id">org.gnu.emacs.desktop</launchable>
+  <launchable type="service">emacs.service</launchable>
+  <project_group>GNU</project_group>
+  <project_license>GPL-3.0+ and GFDL-1.3+</project_license>
+-- 
+2.35.1
+

--- a/metainfo-releases.patch
+++ b/metainfo-releases.patch
@@ -1,0 +1,33 @@
+From 2ed79c5c5f1412ea202422eb1f32400155531e05 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joonas=20Saraj=C3=A4rvi?= <muep@iki.fi>
+Date: Mon, 4 Apr 2022 20:20:12 +0300
+Subject: [PATCH] Add releases element to metainfo.xml
+
+---
+ etc/emacs.metainfo.xml | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/etc/emacs.metainfo.xml b/etc/emacs.metainfo.xml
+index 11df8a7159..65234f87f4 100644
+--- a/etc/emacs.metainfo.xml
++++ b/etc/emacs.metainfo.xml
+@@ -45,4 +45,16 @@
+   </screenshot>
+  </screenshots>
+  <update_contact>emacs-devel_AT_gnu.org</update_contact>
++ <releases>
++   <release date="2024-03-24" version="29.3"/>
++   <release date="2024-01-18" version="29.2"/>
++   <release date="2023-07-30" version="29.1"/>
++   <release date="2022-09-12" version="28.2"/>
++   <release date="2022-04-04" version="28.1"/>
++   <release date="2021-03-25" version="27.2"/>
++   <release date="2020-08-11" version="27.1"/>
++   <release date="2019-08-28" version="26.3"/>
++   <release date="2019-04-12" version="26.2"/>
++   <release date="2018-05-28" version="26.1"/>
++ </releases>
+ </component>
+-- 
+2.35.1
+

--- a/metainfo-screenshot-size.patch
+++ b/metainfo-screenshot-size.patch
@@ -1,0 +1,25 @@
+From d0f388884331b65d0da655ce89a671240210739a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joonas=20Saraj=C3=A4rvi?= <muep@iki.fi>
+Date: Mon, 4 Apr 2022 20:32:11 +0300
+Subject: [PATCH] Fix size attributes of the screenshot
+
+---
+ etc/emacs.metainfo.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/etc/emacs.metainfo.xml b/etc/emacs.metainfo.xml
+index 37c5debc7a..19c7d5c675 100644
+--- a/etc/emacs.metainfo.xml
++++ b/etc/emacs.metainfo.xml
+@@ -40,7 +40,7 @@
+  <developer_name>Free Software Foundation</developer_name>
+  <screenshots>
+   <screenshot type="default">
+-    <image type="source" width="632" height="354">https://www.gnu.org/software/emacs/images/appdata-26.png</image>
++    <image type="source" width="1024" height="576">https://www.gnu.org/software/emacs/images/appdata-26.png</image>
+     <caption>Editing a Lisp program whilst viewing the Emacs manual.</caption>
+   </screenshot>
+  </screenshots>
+-- 
+2.35.1
+

--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -1,5 +1,5 @@
 {
-    "app-id": "org.gnu.emacs-pgtk",
+    "app-id": "org.gnu.emacs",
     "runtime" : "org.gnome.Sdk",
     "runtime-version" : "45",
     "sdk" : "org.gnome.Sdk",
@@ -36,26 +36,6 @@
         "cxxflags": "-O2"
     },
     "modules": [
-	{
-            "name": "jansson",
-	    "buildsystem": "cmake",
-	    "config-opts": [
-		"-DJANSSON_BUILD_DOCS=OFF",
-		"-DJANSSON_EXAMPLES=OFF",
-		"-DCMAKE_BUILD_TYPE=Release",
-		"-DJANSSON_WITHOUT_TESTS=ON"
-	    ],
-            "sources": [
-                {
-		    "type": "git",
-                    "url": "https://github.com/akheron/jansson.git",
-		    "tag": "v2.14"
-                }
-            ],
-	    "cleanup": [
-		"*"
-	    ]
-        },
 	{
 	    "name": "treesitter",
 	    "buildsystem": "simple",
@@ -189,7 +169,6 @@
                 "--with-gnutls",
 		"--with-tree-sitter",
 		"--with-modules",
-		"--with-json",
 		"--with-pgtk",
 		"--with-zlib",
 		"--with-native-compilation"
@@ -201,15 +180,31 @@
                 },
                 {
                     "type": "patch",
-                    "path": "appdata-launchable.patch"
-                },
-                {
-                    "type": "patch",
                     "path": "appdata-id.patch"
                 },
 	        {
                     "type": "patch",
                     "path": "desktop-rename.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "metainfo-releases.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "metainfo-launchable.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "metainfo-content-rating.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "metainfo-screenshot-size.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "metainfo-caption-point.patch"
                 }
             ],
             "cleanup": [

--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -218,7 +218,7 @@
                 "/share/icons/hicolor/scalable/mimetypes/emacs-document23.svg"
             ]
         },
-		{
+	{
             "name": "podman-wrapper",
             "buildsystem": "simple",
             "build-commands": [


### PR DESCRIPTION
with the recent inclusion of a custom json parser in emacs we no longer need libjansson for fast json decoding

closes #16 